### PR TITLE
Support description/comments for table and columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ module "stats_view" {
   source = "github.com/iconara/terraform-aws-athena-view"
   database_name = "analytics"
   name = "stats"
+  description = "Best stats ever"
   sql = "SELECT name, COUNT(*) AS count FROM data GROUP BY 1 ORDER BY 2 DESC"
   columns = [
     {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ module "stats_view" {
       name = "name",
       hive_type = "string",
       presto_type = "varchar",
+      comment = "This is the name"
     },
     {
       name = "count",

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ locals {
 resource "aws_glue_catalog_table" "view" {
   name = var.name
   database_name = var.database_name
+  description = var.description
   table_type = "VIRTUAL_VIEW"
   parameters = {
     presto_view = "true"

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ resource "aws_glue_catalog_table" "view" {
       content {
         name = columns.value.name
         type = columns.value.hive_type
+        comment = columns.value.comment
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "name" {
   description = "The name of the view"
 }
 
+variable "description" {
+  type = string
+  description = "The description of the glue table"
+  default = null
+}
+
 variable "sql" {
   type = string
   description = "The SQL of the view (not including CREATE VIEW …)"

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "sql" {
 }
 
 variable "columns" {
-  type = list(object({name = string, hive_type = string, presto_type = string}))
+  type = list(object({name = string, hive_type = string, presto_type = string, comment = optional(string)}))
   description = <<EOT
 A list of the names and types of the columns of the view, using both Hive and Presto types.
 Views are complex structures in Athena, and the column names are repeated in multiple places in the metadata.


### PR DESCRIPTION
This allows setting the description of the glue table and comments on the glue tables columns.