### PR TITLE
Allow setting additional glue table paremeters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,9 @@ resource "aws_glue_catalog_table" "view" {
   name = var.name
   database_name = var.database_name
   table_type = "VIRTUAL_VIEW"
-  parameters = {
+  parameters = merge(var.parameters, {
     presto_view = "true"
-  }
+  })
   view_original_text = "/* Presto View: ${base64encode(local.presto_view)} */"
   storage_descriptor {
     ser_de_info {

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,9 @@ between the columns specified here and the actual columns produced by the view S
 saying that the view is "stale".
 EOT
 }
+
+variable "parameters" {
+  type = map(string)
+  default = {}
+  description = "Additional Glue table parameters"
+}


### PR DESCRIPTION
E.g. `federated_catalogs_list = "some-external-database"`